### PR TITLE
Adding LINESTRING support to poi_poly

### DIFF
--- a/poi-only.yml
+++ b/poi-only.yml
@@ -25,7 +25,14 @@ tables:
       emergency: [__any__]
       # It is IMO a bad tagging decision that we need those :(
       playground: [__any__]
-      camp_site: [__any__]    
+      camp_site: [__any__]
+    type: linestring
+    mapping:
+      historic: [__any__]
+      man_made: [__any__]
+      emergency: [__any__]
+      # It is IMO a bad tagging decision that we need those :(
+      playground: [__any__]     
 
   poi_point:
     fields:


### PR DESCRIPTION
See https://github.com/babykarte/babykarte/issues/45 where a [playground equipment feature](https://www.openstreetmap.org/way/566960842) has been mapped as LINESTRING and not shown in database or in playground statistics because of being not imported.